### PR TITLE
update images to be more stable in resolving remote dependencies

### DIFF
--- a/phmxversecore-versioned/Dockerfile
+++ b/phmxversecore-versioned/Dockerfile
@@ -3,6 +3,8 @@ MAINTAINER "Devin Pastoor" devin.pastoor@gmail.com
 
 ## littler installGithub should be simlinked already 
 # from the base R image
-RUN installGithub.r --deps TRUE \
-    dpastoor/phmxversecore
+RUN wget https://gist.githubusercontent.com/dpastoor/0bf40c3d0df2ef5bd961dd3acf5aa0bf/raw/28dde0f7e186159ac924f87dd644eda8766d0437/install_github.r -O install_github.r \
+  && chmod +x install_github.r
+
+RUN ./install_github.r dpastoor/phmxversecore 
     

--- a/phmxversecore-versioned/tip/Dockerfile
+++ b/phmxversecore-versioned/tip/Dockerfile
@@ -4,6 +4,6 @@ MAINTAINER "Devin Pastoor" devin.pastoor@gmail.com
 ## littler installGithub should be simlinked already 
 # from the base R image
 RUN install2.r bindrcpp \
-&& installGithub.r --deps TRUE \
+&& ./install_github.r \
     tidyverse/dplyr tidyverse/tidyr tidyverse/purrr hadley/purrrlyr
     


### PR DESCRIPTION
I have had trouble in the past as well with the installGithub.r script, when the package description files also have Remotes, hence this PR represents a shift to using remotes to install, as it does a better job in actually resolving the Remotes.